### PR TITLE
ヘッダーの作成とホーム画面コンポーネントの作成

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,10 @@
     "extends": [
       "react-app",
       "react-app/jest"
-    ]
+    ],
+    "rules": {
+      "react-hooks/exhaustive-deps": "off"
+    }
   },
   "browserslist": {
     "production": [

--- a/frontend/src/components/molecules/MenuDrawer.tsx
+++ b/frontend/src/components/molecules/MenuDrawer.tsx
@@ -1,0 +1,35 @@
+import {
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerOverlay,
+} from '@chakra-ui/react';
+import { FC, memo } from 'react';
+import { useScreenTransition } from '../../hooks/useScreenTransition';
+
+type Props = {
+  onClose: () => void;
+  isOpen: boolean;
+};
+
+export const MenuDrawer: FC<Props> = memo((props) => {
+  const { onClickArticles, onClickSetting } = useScreenTransition();
+  const { onClose, isOpen } = props;
+  return (
+    <Drawer onClose={onClose} isOpen={isOpen} size="xs" placement="left">
+      <DrawerOverlay>
+        <DrawerContent>
+          <DrawerBody bg="gray.100" pt={3}>
+            <Button onClick={onClickArticles} w="100%">
+              記事一覧
+            </Button>
+            <Button onClick={onClickSetting} w="100%">
+              設定
+            </Button>
+          </DrawerBody>
+        </DrawerContent>
+      </DrawerOverlay>
+    </Drawer>
+  );
+});

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -1,0 +1,55 @@
+import { HamburgerIcon } from '@chakra-ui/icons';
+import {
+  Box,
+  Flex,
+  Heading,
+  IconButton,
+  useDisclosure,
+  Link,
+} from '@chakra-ui/react';
+import { FC, memo } from 'react';
+
+import { useScreenTransition } from '../../hooks/useScreenTransition';
+import { MenuDrawer } from '../molecules/MenuDrawer';
+
+export const Header: FC = memo(() => {
+  const { onClose, onOpen, isOpen } = useDisclosure();
+  const { onClickArticles, onClickSetting, onClickHome } =
+    useScreenTransition();
+  return (
+    <>
+      <Flex
+        as="nav"
+        bg="teal.500"
+        color="gray.50"
+        align="center"
+        justify="space-between"
+      >
+        <Heading
+          as="h1"
+          fontSize={{ base: 'md', md: 'lg' }}
+          padding={{ base: 3, md: 5 }}
+          onClick={onClickHome}
+          _hover={{ cursor: 'pointer' }}
+        >
+          記事管理アプリ
+        </Heading>
+        <Flex flexGrow={2} display={{ base: 'none', md: 'flex' }}>
+          <Box pr={3}>
+            <Link onClick={onClickArticles}>記事一覧</Link>
+          </Box>
+          <Link onClick={onClickSetting}>設定</Link>
+        </Flex>
+        <IconButton
+          aria-label="メニューボタン"
+          icon={<HamburgerIcon />}
+          size="sm"
+          display={{ base: 'block', md: 'none' }}
+          variant="unstyled"
+          onClick={onOpen}
+        />
+      </Flex>
+      <MenuDrawer onClose={onClose} isOpen={isOpen} />
+    </>
+  );
+});

--- a/frontend/src/components/pages/Home.tsx
+++ b/frontend/src/components/pages/Home.tsx
@@ -1,0 +1,5 @@
+import { FC, memo } from 'react';
+
+export const Home: FC = memo(() => {
+  return <h1>ホーム画面</h1>;
+});

--- a/frontend/src/components/pages/Page404.tsx
+++ b/frontend/src/components/pages/Page404.tsx
@@ -1,0 +1,5 @@
+import { FC, memo } from 'react';
+
+export const Page404: FC = memo(() => {
+  return <h1>404ページです</h1>;
+});

--- a/frontend/src/components/pages/Setting.tsx
+++ b/frontend/src/components/pages/Setting.tsx
@@ -1,0 +1,5 @@
+import { FC, memo } from 'react';
+
+export const Setting: FC = memo(() => {
+  return <h1>設定画面</h1>;
+});

--- a/frontend/src/components/templates/HeaderLayout.tsx
+++ b/frontend/src/components/templates/HeaderLayout.tsx
@@ -1,0 +1,16 @@
+import { FC, ReactNode, memo } from 'react';
+import { Header } from '../organisms/Header';
+
+type Props = {
+  children: ReactNode;
+};
+
+export const HeaderLayout: FC<Props> = memo((props) => {
+  const { children } = props;
+  return (
+    <>
+      <Header />
+      {children}
+    </>
+  );
+});

--- a/frontend/src/hooks/useScreenTransition.ts
+++ b/frontend/src/hooks/useScreenTransition.ts
@@ -1,0 +1,12 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const useScreenTransition = () => {
+  const navigate = useNavigate();
+
+  const onClickArticles = useCallback(() => navigate("/articles"), []);
+  const onClickSetting = useCallback(() => navigate("/setting"), []);
+  const onClickHome = useCallback(() => navigate("/home"), []);
+
+  return { onClickArticles, onClickSetting, onClickHome };
+};

--- a/frontend/src/router/ArticleRoutes .tsx
+++ b/frontend/src/router/ArticleRoutes .tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+import { Articles } from '../components/pages/Articles';
+import { ArticleDetail } from '../components/pages/ArticleDetail';
+
+export const ArticleRoutes: Array<{ path: string; children: ReactNode }> = [
+  {
+    path: '',
+    children: <Articles />,
+  },
+  {
+    path: ':id',
+    children: <ArticleDetail />,
+  },
+];

--- a/frontend/src/router/Router.tsx
+++ b/frontend/src/router/Router.tsx
@@ -1,18 +1,41 @@
 import { FC, memo } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
-import { Articles } from '../components/pages/Articles';
-import { ArticleDetail } from '../components/pages/ArticleDetail';
 import { Login } from '../components/pages/Login';
+import { Page404 } from '../components/pages/Page404';
+import { HeaderLayout } from '../components/templates/HeaderLayout';
+import { ArticleRoutes } from './ArticleRoutes ';
+import { Home } from '../components/pages/Home';
 
 export const Router: FC = memo(() => {
   return (
     <Routes>
+      <Route
+        path="/home"
+        element={
+          <HeaderLayout>
+            <Home />
+          </HeaderLayout>
+        }
+      />
       <Route path="/articles">
-        <Route path="" element={<Articles />} />
-        <Route path=":id" element={<ArticleDetail />} />
+        {ArticleRoutes.map((urls) => (
+          <Route
+            key={urls.path}
+            path={urls.path}
+            element={<HeaderLayout>{urls.children}</HeaderLayout>}
+          />
+        ))}
       </Route>
       <Route path="/login" element={<Login />} />
+      <Route
+        path="*"
+        element={
+          <HeaderLayout>
+            <Page404 />
+          </HeaderLayout>
+        }
+      />
     </Routes>
   );
 });


### PR DESCRIPTION
# 概要
- ログイン画面以外に実装予定のヘッダーの作成と実装
## ヘッダーの仕様
- スマホ画面をデフォルトとしたレスポンシブ対応
- スマホ画面の際は、リンクをヘッダに表示せず、サイドメニューとして表示
## 設定ファイルの修正
- `package.json`を修正
- useCallback の第二引数を空のリストにしても, `eslint` で警告が出ないようにした。